### PR TITLE
Tag documentation links for attribution, and repair every broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IronWord.Examples
 
-Runnable C# examples for [IronWord](https://ironsoftware.com/csharp/word/), a .NET library for creating, reading, and editing DOCX files without Microsoft Word or Office Interop.
+Runnable C# examples for [IronWord](https://ironsoftware.com/csharp/word/?utm_source=github), a .NET library for creating, reading, and editing DOCX files without Microsoft Word or Office Interop.
 
 ## Install
 
@@ -52,15 +52,15 @@ Each folder contains a self-contained .NET project you can open and run:
 
 ## Platform support
 
-.NET 10, 9, 8, 7, 6, 5, .NET Core 2x/3x, .NET Standard 2, and .NET Framework 4.6.2+. Windows, macOS, Linux, Docker, Azure, and AWS. See the [installation docs](https://ironsoftware.com/csharp/word/docs/) for environment-specific notes.
+.NET 10, 9, 8, 7, 6, 5, .NET Core 2x/3x, .NET Standard 2, and .NET Framework 4.6.2+. Windows, macOS, Linux, Docker, Azure, and AWS. See the [installation docs](https://ironsoftware.com/csharp/word/docs/?utm_source=github) for environment-specific notes.
 
 ## Documentation and support
 
-- Full documentation: [ironsoftware.com/csharp/word/docs](https://ironsoftware.com/csharp/word/docs/)
-- API reference: [ironsoftware.com/csharp/word/object-reference/api](https://ironsoftware.com/csharp/word/object-reference/api/)
+- Full documentation: [ironsoftware.com/csharp/word/docs](https://ironsoftware.com/csharp/word/docs/?utm_source=github)
+- API reference: [ironsoftware.com/csharp/word/object-reference/api](https://ironsoftware.com/csharp/word/object-reference/api/?utm_source=github)
 - Issues with these examples: file directly on this repository
 - Product support: [support@ironsoftware.com](mailto:support@ironsoftware.com)
 
 ## About
 
-This repository is maintained by [Iron Software](https://ironsoftware.com/). IronWord is a commercial library — see [licensing](https://ironsoftware.com/csharp/word/licensing/) for terms and trial details.
+This repository is maintained by [Iron Software](https://ironsoftware.com/?utm_source=github). IronWord is a commercial library — see [licensing](https://ironsoftware.com/csharp/word/licensing/?utm_source=github) for terms and trial details.

--- a/examples/add-image/README.md
+++ b/examples/add-image/README.md
@@ -1,5 +1,5 @@
-> Full guide: [Add image](https://ironsoftware.com/csharp/word/examples/add-image/)
+> Full guide: [Add image](https://ironsoftware.com/csharp/word/examples/add-image/?utm_source=github)
 
 The following code example illustrates the process of opening a Word document, setting up an image with precise dimensions, and integrating this image into the document. First, a new `Paragraph` object is instantiated to hold the image. The `AddImage` method of the paragraph is then utilized to insert the image. Next, this paragraph, which now includes the image, is appended to the document via the `AddParagraph` method. To conclude, the newly updated document is saved.
 
-[Learn more about Document Elements in this detailed tutorial.](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Learn more about Document Elements in this detailed tutorial.](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/add-list/README.md
+++ b/examples/add-list/README.md
@@ -1,5 +1,5 @@
-> Full guide: [Add list](https://ironsoftware.com/csharp/word/examples/add-list/)
+> Full guide: [Add list](https://ironsoftware.com/csharp/word/examples/add-list/?utm_source=github)
 
 This sample demonstrates how easily you can create a well-organized Word document featuring a multi-tiered list utilizing the IronWord library in C#.
 
-[Explore Document Elements with IronWord](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Explore Document Elements with IronWord](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/add-paragraph/README.md
+++ b/examples/add-paragraph/README.md
@@ -1,4 +1,4 @@
-> Full guide: [Add paragraph](https://ironsoftware.com/csharp/word/examples/add-paragraph/)
+> Full guide: [Add paragraph](https://ironsoftware.com/csharp/word/examples/add-paragraph/?utm_source=github)
 
 The IronWord "add-paragraph" capability enables developers to insert entire paragraphs into a Word document. This functionality is essential for efficiently structuring and organizing different segments of text into a unified section. Suitable for dynamic documents such as reports, articles, or letters, this feature supports grouping and styling text together.
 
@@ -12,4 +12,4 @@ This functionality comes with formatting options, allowing for the application o
 4. **Embedding Paragraph into Document:** Following the text insertion, use the `AddParagraph` method on the `WordDocument` instance to integrate the paragraph into the main document. This method assures the paragraph's correct placement, preserving the document’s structural integrity and layout.
 5. **Document Preservation:** Conclude by calling the `SaveAs` method to save the document as `"document.docx"` on your local disk. This saves all previous modifications to the new DOCX file, encapsulating the recently added paragraph.
 
-[Explore more on Document Elements with IronWord](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Explore more on Document Elements with IronWord](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/add-style-text/README.md
+++ b/examples/add-style-text/README.md
@@ -1,4 +1,4 @@
-> Full guide: [Add style text](https://ironsoftware.com/csharp/word/examples/add-style-text/)
+> Full guide: [Add style text](https://ironsoftware.com/csharp/word/examples/add-style-text/?utm_source=github)
 
 The "Add Style Text" capability in IronWord provides developers the tools to include a variety of text styles when integrating content into a DOCX file. This function allows precise customization of text attributes, including font type, size, color, and styles such as bold, italic, underline, and strike-through. Developers can configure a `Text` object's `TextStyle`, enabling them to define the visual elements of text sections on a granular level and ensure the document maintains a polished and tailored appearance.
 
@@ -10,4 +10,4 @@ The following code sample demonstrates the procedure for adding and styling text
 
 Once the text has been appropriately styled, it is added to the document using the `AddText` method. This function integrates the configured text into the DOCX format. To finalize the process, the `SaveAs` method is utilized, exporting the document as "`styled_document.docx`". As a result, the Word document will contain the text with the designated styles, ensuring all typography and formatting characteristics are retained in the exported file.
 
-[Explore Document Element Tutorials for More Styling Tips](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Explore Document Element Tutorials for More Styling Tips](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/add-table/README.md
+++ b/examples/add-table/README.md
@@ -1,7 +1,7 @@
-> Full guide: [Add table](https://ironsoftware.com/csharp/word/examples/add-table/)
+> Full guide: [Add table](https://ironsoftware.com/csharp/word/examples/add-table/?utm_source=github)
 
 A table consists of a systematic array of cells positioned in ordered rows and columns. This essential tool aids in the structured presentation and arrangement of data. Each cell represents the crossing point between a row and a column, and tables are used for schedules, collected data, and anything else that reads better in rows.
 
 To introduce a table using IronWord, begin by establishing the table object with a defined number of rows and columns to suit your needs. You can then proceed to tailor the style of the entire table as desired. Each cell within the table is accessible through the **[row, column]** index, where you can apply individual styling and integrate various document elements like text runs, paragraphs, images, and shapes. After configuring the table structure, this object can then be employed to generate a new Word document.
 
-[Learn How to Add Tables in Word with IronWord](https://ironsoftware.com/csharp/word/how-to/add-table/)
+[Learn How to Add Tables in Word with IronWord](https://ironsoftware.com/csharp/word/how-to/add-table/?utm_source=github)

--- a/examples/add-text-effect-glow-effect/README.md
+++ b/examples/add-text-effect-glow-effect/README.md
@@ -1,7 +1,7 @@
-> Full guide: [Add text effect glow effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-glow-effect/)
+> Full guide: [Add text effect glow effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-glow-effect/?utm_source=github)
 
 The code example provided illustrates the steps for generating a new Word document and incorporating a text style with a glow effect. Initially, a fresh `Word` document is created and assigned to the `doc` variable. Subsequently, a `TextStyle` object, dubbed `textStyle`, is established. This text style integrates a glow effect by configuring a `TextEffect` object with precise settings. The phrase "Hello World" is inputted into the document, and then the `textStyle` featuring the glow effect is applied to this text. The document is finally saved as a new file.
 
-For additional information and practical tutorials, please visit: [**How to Add Glow Effect to Text**](https://ironsoftware.com/csharp/word/how-to/text-effect-glow-effect/).
+For additional information and practical tutorials, please visit: [**How to Add Glow Effect to Text**](https://ironsoftware.com/csharp/word/how-to/text-effect-glow-effect/?utm_source=github).
 
-[Learn More About Document Elements in IronWord](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Learn More About Document Elements in IronWord](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/add-text-effect-gradient-effect/README.md
+++ b/examples/add-text-effect-gradient-effect/README.md
@@ -1,7 +1,7 @@
-> Full guide: [Add text effect gradient effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-gradient-effect/)
+> Full guide: [Add text effect gradient effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-gradient-effect/?utm_source=github)
 
 The code snippet provided illustrates the process of adding a gradient effect to text within a new Word document. Initially, a `WordDocument` instance is created. Following this, a `TextStyle` object is set up, and it is configured to embody a gradient effect. This is achieved by setting the `GradientEffect` property to `Gradient.DefaultGray`. The prepared `TextStyle` is then applied to the string "Hello World", which is then added to the document. At the conclusion of these steps, the document is exported, containing the styled text.
 
-For additional examples and detailed guidance, kindly visit the article here: [How to Add Gradient Effect to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-gradient-effect/).
+For additional examples and detailed guidance, kindly visit the article here: [How to Add Gradient Effect to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-gradient-effect/?utm_source=github).
 
-[Explore More Word Document Element Tutorials Here](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Explore More Word Document Element Tutorials Here](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/add-text-effect-reflection-effect/README.md
+++ b/examples/add-text-effect-reflection-effect/README.md
@@ -1,5 +1,5 @@
-> Full guide: [Add text effect reflection effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-reflection-effect/)
+> Full guide: [Add text effect reflection effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-reflection-effect/?utm_source=github)
 
 Create a new MS Word document and insert text embellished with a reflection effect. We start by creating a `WordDocument` object named `doc`. Next, a `TextStyle` object is defined. This style is enhanced by adding a reflection effect, achieved by setting its `TextEffect` property to a new `Reflection` object. Following this configuration, the text "Hello World" is inserted into the document using this style. This process culminates with the document being saved.
 
-Discover more about document elements in IronWord by visiting [IronWord tutorials on Document Elements](https://ironsoftware.com/csharp/word/tutorials/document-element/).
+Discover more about document elements in IronWord by visiting [IronWord tutorials on Document Elements](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github).

--- a/examples/add-text-effect-shadow-effect/README.md
+++ b/examples/add-text-effect-shadow-effect/README.md
@@ -1,7 +1,7 @@
-> Full guide: [Add text effect shadow effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-shadow-effect/)
+> Full guide: [Add text effect shadow effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-shadow-effect/?utm_source=github)
 
 You can easily add a shadow effect to text in a Word document using a few simple lines of code. To start, let's initiate a new instance of `WordDocument` and name it `doc`. Next, we create a `TextStyle` object and set its shadow effect by assigning the `Shadow.OuterShadow1` to the `TextEffect` property. After configuring the `TextStyle`, we add the text "Hello World" to the document using this style. When you're done, just export the Word document.
 
-For additional examples and demonstrations, feel free to visit the following article: [How to Add Shadow Effect to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-shadow-effect/)
+For additional examples and demonstrations, feel free to visit the following article: [How to Add Shadow Effect to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-shadow-effect/?utm_source=github)
 
-[Explore Document Elements with IronWord Tutorials.](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Explore Document Elements with IronWord Tutorials.](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/add-text-effect-text-outline-effect/README.md
+++ b/examples/add-text-effect-text-outline-effect/README.md
@@ -1,5 +1,5 @@
-> Full guide: [Add text effect text outline effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-text-outline-effect/)
+> Full guide: [Add text effect text outline effect](https://ironsoftware.com/csharp/word/examples/add-text-effect-text-outline-effect/?utm_source=github)
 
 Applying a text outline with IronWord is incredibly straightforward, yet it offers full customization for all its attributes. Start by importing a Word document. Next, configure the `textStyle` by setting `TextOutlineEffect.DefaultEffect` as the value for the **TextOutlineEffect** property on a newly created `TextEffect` instance. You can apply this effect to any amount of text you need. Once done, export your document to finalize the changes.
 
-[Learn more about Document Elements with IronWord.](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Learn more about Document Elements with IronWord.](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/add-text/README.md
+++ b/examples/add-text/README.md
@@ -1,5 +1,5 @@
-> Full guide: [Add text](https://ironsoftware.com/csharp/word/examples/add-text/)
+> Full guide: [Add text](https://ironsoftware.com/csharp/word/examples/add-text/?utm_source=github)
 
 This task loads an existing Word document, inserts text into it, and saves the result. The code below walks through each step:
 
-[Discover the Document Elements with IronWord Tutorial](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Discover the Document Elements with IronWord Tutorial](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/create-empty-word/README.md
+++ b/examples/create-empty-word/README.md
@@ -1,7 +1,7 @@
-> Full guide: [Create empty word](https://ironsoftware.com/csharp/word/examples/create-empty-word/)
+> Full guide: [Create empty word](https://ironsoftware.com/csharp/word/examples/create-empty-word/?utm_source=github)
 
 ## IronWord: Simplifying Word and DOCX Document Creation
 
 IronWord simplifies the process of creating Word and DOCX documents. Start by creating a new `WordDocument` object. Then, structure your document by adding elements like paragraphs, tables, and sections, all of which can be incorporated directly into your new Word document. Once your document is structured to your satisfaction, you can save your work using the `SaveAs` method.
 
-[Discover the Document Structuring with IronWord Guide](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Discover the Document Structuring with IronWord Guide](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/create-word-from-text/README.md
+++ b/examples/create-word-from-text/README.md
@@ -1,5 +1,5 @@
-> Full guide: [Create word from text](https://ironsoftware.com/csharp/word/examples/create-word-from-text/)
+> Full guide: [Create word from text](https://ironsoftware.com/csharp/word/examples/create-word-from-text/?utm_source=github)
 
 Creating a Word document from scratch using different document elements like paragraphs, tables, or sections is straightforward. Simply pass any of these elements to initiate the creation of a new Word document. Then, apply the `SaveAs` method to save your newly formed document.
 
-[Explore Our Document Element Tutorial for IronWord](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Explore Our Document Element Tutorial for IronWord](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/edit-text/README.md
+++ b/examples/edit-text/README.md
@@ -1,4 +1,4 @@
-> Full guide: [Edit text](https://ironsoftware.com/csharp/word/examples/edit-text/)
+> Full guide: [Edit text](https://ironsoftware.com/csharp/word/examples/edit-text/?utm_source=github)
 
 The "Edit Text" function in IronWord equips developers with the capability to modify text in an existing DOCX file. By utilizing the `Paragraphs` collection, developers can pinpoint and alter the `Text` objects within paragraphs using the `ReplaceText` method. This functionality is essential for scenarios that require dynamic text updates such as modifying report sections, replacing placeholder text, or amending content based on external data or user inputs.
 
@@ -18,4 +18,4 @@ This snippet illustrates how to edit text within a Word document using IronWord.
 
 The flexibility of this setup becomes apparent with more dynamic content adjustment needs. For instance, the second change involves navigating deeper within the second paragraph. Like the prior instance, `Paragraphs` collection access is followed by narrowing down through the `Texts` array and the `Text` property, allowing precise, confident updates to existing content.
 
-[Explore Document Elements in IronWord Tutorial](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+[Explore Document Elements in IronWord Tutorial](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)

--- a/examples/extract-text/README.md
+++ b/examples/extract-text/README.md
@@ -1,4 +1,4 @@
-> Full guide: [Extract text](https://ironsoftware.com/csharp/word/examples/extract-text/)
+> Full guide: [Extract text](https://ironsoftware.com/csharp/word/examples/extract-text/?utm_source=github)
 
 Extracting an extensive amount of text from documents can often be a tedious and lengthy process, particularly when faced with copious amounts of paragraphs and tables. Fortunately, the `ExtractText` method from IronWord offers a timely solution. This method allows developers to efficiently extract a defined amount of text from a document, removing the need for repetitive looping and facilitating easier access to the `Text` property. By using this method, developers can enhance their productivity and conserve valuable time.
 
@@ -22,4 +22,4 @@ Although the previously described example extracts all text from the document, t
 
 When referencing an index from the `Paragraphs`, it fetches and extracts text only from the document's initial paragraph, subsequently outputting it to the console. Similarly, the `Last` method is utilized on the `Paragraphs` array to extract and output only the text from the document’s concluding paragraph.
 
-[Explore the IronWord API for Advanced Text Extraction](https://ironsoftware.com/csharp/word/object-reference/api/IronWord.html)
+[Explore the IronWord API for Advanced Text Extraction](https://ironsoftware.com/csharp/word/object-reference/api/IronWord.html?utm_source=github)

--- a/examples/log-object-tree/README.md
+++ b/examples/log-object-tree/README.md
@@ -1,5 +1,5 @@
-> Full guide: [Log object tree](https://ironsoftware.com/csharp/word/examples/log-object-tree/)
+> Full guide: [Log object tree](https://ironsoftware.com/csharp/word/examples/log-object-tree/?utm_source=github)
 
 Logging the object structure while crafting a Word document equips developers with crucial debugging tools and insights, making it easier to spot and resolve errors or inconsistencies in the document's framework. Examining the object structure also contributes to performance enhancements by pinpointing and addressing inefficiencies during construction. In essence, logging the object structure enhances the development workflow, facilitating the production of superior Word documents efficiently.
 
-[Explore Document Elements with IronWord Tutorial](https://ironsoftware.com/csharp/word/tutorials/document-element/).
+[Explore Document Elements with IronWord Tutorial](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github).

--- a/get-started/android/README.md
+++ b/get-started/android/README.md
@@ -1,6 +1,6 @@
 # Reading and Writing Word Documents on Android with .NET MAUI
 
-> Full guide: [Reading and Writing Word Documents on Android with .NET MAUI](https://ironsoftware.com/csharp/word/get-started/android/)
+> Full guide: [Reading and Writing Word Documents on Android with .NET MAUI](https://ironsoftware.com/csharp/word/get-started/android/?utm_source=github)
 
 
 .NET MAUI (Multi-platform App UI) provides a framework for developers to create native applications for Android, iOS, macOS, and Windows using a single C# codebase. This unified approach not only simplifies the development process but also ensures native performance across all platforms.

--- a/get-started/aws/README.md
+++ b/get-started/aws/README.md
@@ -1,6 +1,6 @@
 # Utilizing IronWord with AWS Lambda
 
-> Full guide: [Utilizing IronWord with AWS Lambda](https://ironsoftware.com/csharp/word/get-started/aws/)
+> Full guide: [Utilizing IronWord with AWS Lambda](https://ironsoftware.com/csharp/word/get-started/aws/?utm_source=github)
 
 
 This guide outlines the steps for implementing IronWord in an AWS Lambda environment. By the end of this article, you will know how to configure IronWord to generate and modify Word documents on AWS Lambda.

--- a/get-started/azure/README.md
+++ b/get-started/azure/README.md
@@ -1,6 +1,6 @@
 # How To Utilize IronWord on Azure with .NET
 
-> Full guide: [How To Utilize IronWord on Azure with .NET](https://ironsoftware.com/csharp/word/get-started/azure/)
+> Full guide: [How To Utilize IronWord on Azure with .NET](https://ironsoftware.com/csharp/word/get-started/azure/?utm_source=github)
 
 
 IronWord is a .NET library designed to programmatically create, edit, and review Word documents. It integrates smoothly with multiple Azure services, including Azure App Services, Azure Functions, and Azure Container Instances.

--- a/get-started/docker/README.md
+++ b/get-started/docker/README.md
@@ -1,6 +1,6 @@
 # Implementing IronWord in Docker Environments
 
-> Full guide: [Implementing IronWord in Docker Environments](https://ironsoftware.com/csharp/word/get-started/docker/)
+> Full guide: [Implementing IronWord in Docker Environments](https://ironsoftware.com/csharp/word/get-started/docker/?utm_source=github)
 
 
 IronWord provides comprehensive support in Docker environments across both Linux and Windows platforms. This makes it an excellent choice for deployments on cloud platforms such as Azure, AWS, or any other host compatible with .NET.

--- a/get-started/ios/README.md
+++ b/get-started/ios/README.md
@@ -1,6 +1,6 @@
 # Using IronWord for iOS Development
 
-> Full guide: [Using IronWord for iOS Development](https://ironsoftware.com/csharp/word/get-started/ios/)
+> Full guide: [Using IronWord for iOS Development](https://ironsoftware.com/csharp/word/get-started/ios/?utm_source=github)
 
 
 .NET MAUI (Multi-platform App UI) builds native applications for Android, iOS, Windows, and macOS from one .NET codebase. IronWord creates, reads, edits, and saves Microsoft Word (.docx) documents on each of those platforms, with no installed copy of Microsoft Office.

--- a/get-started/license-keys/README.md
+++ b/get-started/license-keys/README.md
@@ -1,13 +1,13 @@
 # Implementing IronWord License Keys
 
-> Full guide: [Implementing IronWord License Keys](https://ironsoftware.com/csharp/barcode/get-started/license-keys/)
+> Full guide: [Implementing IronWord License Keys](https://ironsoftware.com/csharp/barcode/get-started/license-keys/?utm_source=github)
 
 
 ## Acquiring a License Key
 
 To remove watermarks and deployment restrictions in your projects, obtaining an IronWord license key is essential.
 
-You can [purchase a license key here](https://ironsoftware.com/csharp/word/licensing/) or [register for a free 30-day trial key](https://ironsoftware.com/trial-license).
+You can [purchase a license key here](https://ironsoftware.com/csharp/word/licensing/?utm_source=github) or [register for a free 30-day trial key](https://ironsoftware.com/trial-license?utm_source=github).
 
 ---
 
@@ -43,7 +43,7 @@ Be aware of a licensing issue with IronWord releases prior to [version 2024.3.5]
 - **ASP.NET** projects
 - **.NET Framework version >= 4.6.2**
 
-Licenses specified in `Web.config` may not be recognized. For troubleshooting, refer to our [Web.config Licensing Issues guide](https://ironsoftware.com/csharp/word/troubleshooting/license-key-web.config/).
+Licenses specified in `Web.config` may not be recognized. For troubleshooting, refer to our [Web.config Licensing Issues guide](https://ironsoftware.com/csharp/word/troubleshooting/license-key-web.config/?utm_source=github).
 
 Confirm licensing with `IronWord.License.IsLicensed` to ensure it returns `true`.
 
@@ -93,14 +93,14 @@ A return value of **True** indicates a valid key, ready for use with IronWord. A
 
 ## Step 4: Starting Your Project with IronWord
 
-Kick off your project by following our detailed [IronWord Getting Started Guide](https://ironsoftware.com/csharp/word/docs/).
+Kick off your project by following our detailed [IronWord Getting Started Guide](https://ironsoftware.com/csharp/word/docs/?utm_source=github).
 
 ---
 
 ## Support and Further Assistance
 
-Obtaining a license for commercial usage requires either a purchase or a trial registration, which you can address [here](https://ironsoftware.com/csharp/word/licensing/) and [here](https://ironsoftware.com/trial-license), respectively.
+Obtaining a license for commercial usage requires either a purchase or a trial registration, which you can address [here](https://ironsoftware.com/csharp/word/licensing/?utm_source=github) and [here](https://ironsoftware.com/trial-license?utm_source=github), respectively.
 
-Explore a variety of coding examples, detailed tutorials, and comprehensive docs in our [IronWord specific section](https://ironsoftware.com/csharp/word/).
+Explore a variety of coding examples, detailed tutorials, and comprehensive docs in our [IronWord specific section](https://ironsoftware.com/csharp/word/?utm_source=github).
 
 For queries, contact us directly at <support@ironsoftware.com>.

--- a/get-started/license-keys/README.md
+++ b/get-started/license-keys/README.md
@@ -7,7 +7,7 @@
 
 To remove watermarks and deployment restrictions in your projects, obtaining an IronWord license key is essential.
 
-You can [purchase a license key here](https://ironsoftware.com/csharp/word/licensing/?utm_source=github) or [register for a free 30-day trial key](https://ironsoftware.com/trial-license?utm_source=github).
+You can [purchase a license key here](https://ironsoftware.com/csharp/word/licensing/?utm_source=github) or [register for a free 30-day trial key](https://ironsoftware.com/csharp/word/?utm_source=github#trial-license).
 
 ---
 
@@ -99,7 +99,7 @@ Kick off your project by following our detailed [IronWord Getting Started Guide]
 
 ## Support and Further Assistance
 
-Obtaining a license for commercial usage requires either a purchase or a trial registration, which you can address [here](https://ironsoftware.com/csharp/word/licensing/?utm_source=github) and [here](https://ironsoftware.com/trial-license?utm_source=github), respectively.
+Obtaining a license for commercial usage requires either a purchase or a trial registration, which you can address [here](https://ironsoftware.com/csharp/word/licensing/?utm_source=github) and [here](https://ironsoftware.com/csharp/word/?utm_source=github#trial-license), respectively.
 
 Explore a variety of coding examples, detailed tutorials, and comprehensive docs in our [IronWord specific section](https://ironsoftware.com/csharp/word/?utm_source=github).
 

--- a/get-started/mac/README.md
+++ b/get-started/mac/README.md
@@ -1,6 +1,6 @@
 # Setting Up IronWord on macOS
 
-> Full guide: [Setting Up IronWord on macOS](https://ironsoftware.com/csharp/word/get-started/mac/)
+> Full guide: [Setting Up IronWord on macOS](https://ironsoftware.com/csharp/word/get-started/mac/?utm_source=github)
 
 
 IronWord provides .NET developers with the capability to read, create, and edit Word documents in C# without the need for Microsoft Office. Although it is generally utilized on Windows and Linux, setting up IronWord on macOS is straightforward with proper configuration.

--- a/get-started/windows/README.md
+++ b/get-started/windows/README.md
@@ -1,6 +1,6 @@
 # Implementing IronWord for .NET on Windows Platforms
 
-> Full guide: [Implementing IronWord for .NET on Windows Platforms](https://ironsoftware.com/csharp/word/get-started/windows/)
+> Full guide: [Implementing IronWord for .NET on Windows Platforms](https://ironsoftware.com/csharp/word/get-started/windows/?utm_source=github)
 
 
 IronWord is fully compatible with Windows 10, Windows 11, and Windows Server 2016 or later versions. It integrates with various .NET platforms including .NET 10, 9, 8, 7, 6, .NET Core, .NET Standard 2.0+, and .NET Framework 4.6.2 and higher.

--- a/how-to/add-image/README.md
+++ b/how-to/add-image/README.md
@@ -1,6 +1,6 @@
 # How to Insert an Image into a DOCX File
 
-> Full guide: [How to Insert an Image into a DOCX File](https://ironsoftware.com/csharp/word/how-to/add-image/)
+> Full guide: [How to Insert an Image into a DOCX File](https://ironsoftware.com/csharp/word/how-to/add-image/?utm_source=github)
 
 Integrating images into a Word document (.docx) can significantly enhance its visual appeal and elucidate textual content, such as a sentence or a paragraph. Utilizing IronWord, a C# library tailored for modifying DOCX files, this guide will demonstrate the straightforward process of embedding images within a document in a .NET environment.
 

--- a/how-to/add-style-text/README.md
+++ b/how-to/add-style-text/README.md
@@ -1,6 +1,6 @@
 # Enhancing Text Appearance in DOCX with C&#35; Using IronWord
 
-> Full guide: [Enhancing Text Appearance in DOCX with C&#35; Using IronWord](https://ironsoftware.com/csharp/word/how-to/add-style-text/)
+> Full guide: [Enhancing Text Appearance in DOCX with C&#35; Using IronWord](https://ironsoftware.com/csharp/word/how-to/add-style-text/?utm_source=github)
 
 When crafting professional and visually appealing documents, the ability to style text is crucial. IronWord provides an extensive API for rich text formatting in DOCX files.
 

--- a/how-to/add-table/README.md
+++ b/how-to/add-table/README.md
@@ -1,6 +1,6 @@
 # How to Incorporate Tables into DOCX Documents
 
-> Full guide: [How to Incorporate Tables into DOCX Documents](https://ironsoftware.com/csharp/word/how-to/add-table/)
+> Full guide: [How to Incorporate Tables into DOCX Documents](https://ironsoftware.com/csharp/word/how-to/add-table/?utm_source=github)
 
 
 A table, essentially a structured grid, comprises rows and columns that intersect to form cells. These cells can house a variety of data such as text and numbers, facilitating organized data presentation, schedule creation, and more.

--- a/how-to/add-text/README.md
+++ b/how-to/add-text/README.md
@@ -1,6 +1,6 @@
 # How to Insert Text into a DOCX File Using IronWord
 
-> Full guide: [How to Insert Text into a DOCX File Using IronWord](https://ironsoftware.com/csharp/ppt/how-to/add-text/)
+> Full guide: [How to Insert Text into a DOCX File Using IronWord](https://ironsoftware.com/csharp/ppt/how-to/add-text/?utm_source=github)
 
 Incorporating automated text entry into applications is crucial for creating reports, building templates, and populating data dynamically within applications.
 
@@ -8,7 +8,7 @@ This guide will teach you how to add text to a DOCX file using IronWord.
 
 ## Inserting Text
 
-IronWord simplifies the process of inserting text into a DOCX file. This capability can be expanded to include text with various formats, stylized paragraphs, and more intricate document constructs as detailed in the [styling guide](https://ironsoftware.com/csharp/word/how-to/add-style-text/).
+IronWord simplifies the process of inserting text into a DOCX file. This capability can be expanded to include text with various formats, stylized paragraphs, and more intricate document constructs as detailed in the [styling guide](https://ironsoftware.com/csharp/word/how-to/add-style-text/?utm_source=github).
 
 ```csharp
 using IronWord;

--- a/how-to/edit-text/README.md
+++ b/how-to/edit-text/README.md
@@ -1,6 +1,6 @@
 # How to Modify Text in Word Documents Using C#
 
-> Full guide: [How to Modify Text in Word Documents Using C#](https://ironsoftware.com/csharp/word/how-to/edit-text/)
+> Full guide: [How to Modify Text in Word Documents Using C#](https://ironsoftware.com/csharp/word/how-to/edit-text/?utm_source=github)
 
 Modifying text in Word documents is essential for updating content and managing document revisions. IronWord allows you to directly manipulate the text within paragraph runs, enabling precise edits to DOCX files programmatically.
 

--- a/how-to/extract-images/README.md
+++ b/how-to/extract-images/README.md
@@ -1,6 +1,6 @@
 # Extracting Images from DOCX Files Using C# and IronWord
 
-> Full guide: [Extracting Images from DOCX Files Using C# and IronWord](https://ironsoftware.com/csharp/word/how-to/extract-images/)
+> Full guide: [Extracting Images from DOCX Files Using C# and IronWord](https://ironsoftware.com/csharp/word/how-to/extract-images/?utm_source=github)
 
 IronWord simplifies the task of extracting images from Word documents, a frequent need in content migration, media management, and automated document handling. The library provides powerful tools that enable users to save, analyze, or recycle embedded images by exposing their properties like size and format.
 

--- a/how-to/extract-text/README.md
+++ b/how-to/extract-text/README.md
@@ -1,6 +1,6 @@
 # Extract Text from DOCX with C# using IronWord
 
-> Full guide: [Extract Text from DOCX with C# using IronWord](https://ironsoftware.com/csharp/word/how-to/extract-text/)
+> Full guide: [Extract Text from DOCX with C# using IronWord](https://ironsoftware.com/csharp/word/how-to/extract-text/?utm_source=github)
 
 Retrieving text from DOCX documents is a crucial task in document management and data extraction. IronWord simplifies this process by allowing developers to easily extract text from DOCX files, including paragraphs, tables, and other elements with programmatic ease.
 

--- a/how-to/remove-text/README.md
+++ b/how-to/remove-text/README.md
@@ -1,6 +1,6 @@
 # Removing Text from DOCX in C#
 
-> Full guide: [Removing Text from DOCX in C#](https://ironsoftware.com/csharp/word/how-to/remove-text/)
+> Full guide: [Removing Text from DOCX in C#](https://ironsoftware.com/csharp/word/how-to/remove-text/?utm_source=github)
 
 Extracting text from DOCX files is an essential task in document management, allowing developers to neatly redact or clean up contents from Word documents. This guide will cover several techniques to strip paragraphs, text runs, and diverse elements using IronWord, all while preserving the document's overall structure.
 

--- a/how-to/replace-words/README.md
+++ b/how-to/replace-words/README.md
@@ -1,6 +1,6 @@
 # How to Replace Text in a Word Document
 
-> Full guide: [How to Replace Text in a Word Document](https://ironsoftware.com/csharp/word/how-to/replace-words/)
+> Full guide: [How to Replace Text in a Word Document](https://ironsoftware.com/csharp/word/how-to/replace-words/?utm_source=github)
 
 
 In document automation, specifically altering text in Word documents, there's a frequent requirement for solutions that facilitate the modification of templates, the updating of reports, or the handling of bulk content. IronWord, a C# library, has been crafted to address these needs efficiently and effectively.
@@ -30,7 +30,7 @@ In IronWord, indexation starts from zero for all object lists.
 
 ### Input
 
-In this example, we’ll work with this [sample Word document](https://ironsoftware.com/static-assets/word/how-to/replace-words/sample.docx) which consists of two paragraphs containing the text "old text".
+In this example, we’ll work with this [sample Word document](https://ironsoftware.com/static-assets/word/how-to/replace-words/sample.docx?utm_source=github) which consists of two paragraphs containing the text "old text".
 
 <div style="text-align: center;">
    <img src="https://ironsoftware.com/static-assets/word/how-to/replace-words/sample-input.webp" alt="Sample Docx" style="max-width: 100%; box-shadow: 0px 2px 5px rgba(0,0,0,0.1);">
@@ -59,7 +59,7 @@ doc.SaveAs("updated.docx");
    <img src="https://ironsoftware.com/static-assets/word/how-to/replace-words/updated-output.webp" alt="Output Docx" style="max-width: 100%; box-shadow: 0px 2px 5px rgba(0,0,0,0.1);">
 </div>
 
-In the [modified document](https://ironsoftware.com/static-assets/word/how-to/replace-words/updated.docx), the first paragraph reflects the new text while the second is left unchanged.
+In the [modified document](https://ironsoftware.com/static-assets/word/how-to/replace-words/updated.docx?utm_source=github), the first paragraph reflects the new text while the second is left unchanged.
 
 ## Replacing Multiple Text Instances
 
@@ -94,7 +94,7 @@ doc.SaveAs("updated.docx");
    <img src="https://ironsoftware.com/static-assets/word/how-to/replace-words/updated-multiple-output.webp" alt="Output Multiple Docx" style="max-width: 100%; box-shadow: 0px 2px 5px rgba(0,0,0,0.1);">
 </div>
 
-The [final document](https://ironsoftware.com/static-assets/word/how-to/replace-words/updated.docx) displays that both paragraphs now contain "new text".
+The [final document](https://ironsoftware.com/static-assets/word/how-to/replace-words/updated.docx?utm_source=github) displays that both paragraphs now contain "new text".
 
 #### Finding Text
 

--- a/how-to/text-effect-glow-effect/README.md
+++ b/how-to/text-effect-glow-effect/README.md
@@ -1,6 +1,6 @@
 # Enhancing Text with a Glow Effect
 
-> Full guide: [Enhancing Text with a Glow Effect](https://ironsoftware.com/csharp/word/how-to/text-effect-glow-effect/)
+> Full guide: [Enhancing Text with a Glow Effect](https://ironsoftware.com/csharp/word/how-to/text-effect-glow-effect/?utm_source=github)
 
 A glow effect on text equips it with a luminous aura, making it seem as though the text is backlit. This can vastly improve readability while simultaneously catching the viewer's eye.
 

--- a/how-to/text-effect-gradient-effect/README.md
+++ b/how-to/text-effect-gradient-effect/README.md
@@ -1,6 +1,6 @@
 # Applying Gradient Effects to Text
 
-> Full guide: [Applying Gradient Effects to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-gradient-effect/)
+> Full guide: [Applying Gradient Effects to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-gradient-effect/?utm_source=github)
 
 
 Gradient effects on text create dynamic visual transitions between colors, adding dimensions, enhancing the visual appeal, and making the text visually striking. These effects can either be linear, transitioning colors along a straight path, or radial, emanating from a central point.

--- a/how-to/text-effect-reflection-effect/README.md
+++ b/how-to/text-effect-reflection-effect/README.md
@@ -1,6 +1,6 @@
 # How to Add Reflection Effect to Text
 
-> Full guide: [How to Add Reflection Effect to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-reflection-effect/)
+> Full guide: [How to Add Reflection Effect to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-reflection-effect/?utm_source=github)
 
 
 Creating a reflection effect for text involves producing a mirrored image of the text below it, akin to how it would appear reflected on a surface. This can lend a sense of depth and enhance the visual impact of the text in your design.

--- a/how-to/text-effect-shadow-effect/README.md
+++ b/how-to/text-effect-shadow-effect/README.md
@@ -1,6 +1,6 @@
 # Adding a Shadow Effect to Text
 
-> Full guide: [Adding a Shadow Effect to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-shadow-effect/)
+> Full guide: [Adding a Shadow Effect to Text](https://ironsoftware.com/csharp/word/how-to/text-effect-shadow-effect/?utm_source=github)
 
 
 Applying a shadow effect to text is an effective way to add depth and visual distinction. This technique involves creating a shadow behind the text that is slightly offset, making it appear as if the text is elevated above the background.

--- a/how-to/text-effect-text-outline-effect/README.md
+++ b/how-to/text-effect-text-outline-effect/README.md
@@ -1,6 +1,6 @@
 # Enhancing Text with an Outline Effect
 
-> Full guide: [Enhancing Text with an Outline Effect](https://ironsoftware.com/csharp/word/how-to/text-effect-text-outline-effect/)
+> Full guide: [Enhancing Text with an Outline Effect](https://ironsoftware.com/csharp/word/how-to/text-effect-text-outline-effect/?utm_source=github)
 
 
 The outline effect on text involves adding a distinct, visible border to each character. This effect is not only visually appealing but also enhances the legibility of text, especially against complex backgrounds. Users can tailor this effect by adjusting the color, width, and style of the outline to meet particular design requirements. This technique is widely used across graphic design, typography, and digital creation to give texts a prominent or artistic flair.

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -125,7 +125,7 @@ class Program
 
 ## Licensing & Support Available
 
-**IronWord** offers both commercial licenses and trial versions which can be accessed [here](https://ironsoftware.com/csharp/word/docs/trial-license?utm_source=github).
+**IronWord** offers both commercial licenses and trial versions which can be accessed [here](https://ironsoftware.com/csharp/word/docs/?utm_source=github#trial-license).
 
 For additional information about Iron Software, visit our website at: <https://ironsoftware.com/>. For further assistance and queries, you can [contact our team](https://ironsoftware.com/csharp/word/docs/?utm_source=github#live-chat-support).
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -127,7 +127,7 @@ class Program
 
 **IronWord** offers both commercial licenses and trial versions which can be accessed [here](https://ironsoftware.com/csharp/word/docs/trial-license?utm_source=github).
 
-For additional information about Iron Software, visit our website at: <https://ironsoftware.com/>. For further assistance and queries, you can [contact our team](https://www.ironsoftware.com/csharp/word/docs/?utm_source=github#live-chat-support).
+For additional information about Iron Software, visit our website at: <https://ironsoftware.com/>. For further assistance and queries, you can [contact our team](https://ironsoftware.com/csharp/word/docs/?utm_source=github#live-chat-support).
 
 ### Support from Iron Software
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -1,6 +1,6 @@
 # Getting Started with IronWord
 
-> Docs: [IronWord documentation](https://ironsoftware.com/csharp/word/docs/)
+> Docs: [IronWord documentation](https://ironsoftware.com/csharp/word/docs/?utm_source=github)
 
 
 ## IronWord: Word Document Library for .NET
@@ -125,9 +125,9 @@ class Program
 
 ## Licensing & Support Available
 
-**IronWord** offers both commercial licenses and trial versions which can be accessed [here](https://ironsoftware.com/csharp/word/docs/trial-license).
+**IronWord** offers both commercial licenses and trial versions which can be accessed [here](https://ironsoftware.com/csharp/word/docs/trial-license?utm_source=github).
 
-For additional information about Iron Software, visit our website at: <https://ironsoftware.com/>. For further assistance and queries, you can [contact our team](https://www.ironsoftware.com/csharp/word/docs/#live-chat-support).
+For additional information about Iron Software, visit our website at: <https://ironsoftware.com/>. For further assistance and queries, you can [contact our team](https://www.ironsoftware.com/csharp/word/docs/?utm_source=github#live-chat-support).
 
 ### Support from Iron Software
 

--- a/tutorials/document-element/README.md
+++ b/tutorials/document-element/README.md
@@ -1,6 +1,6 @@
 # Document Element Tutorial
 
-> Full guide: [Document Element Tutorial](https://ironsoftware.com/csharp/word/tutorials/document-element/)
+> Full guide: [Document Element Tutorial](https://ironsoftware.com/csharp/word/tutorials/document-element/?utm_source=github)
 
 
 IronWord is a library designed for .NET C# developers. It facilitates the integration of Word document operations—such as creation, reading, and editing—directly into their software applications. Within a Word document, document elements serve as the foundational components that compile the document's content.


### PR DESCRIPTION
This is the IronWord slice of a corpus-wide pass over the fifteen GitHub
example repositories. Each repo gets the same treatment; the numbers below are
what applied here.

## What changed

**78 documentation links now carry `?utm_source=github`**, so arrivals on
the docs sites can be attributed to these repositories.

Only links a reader clicks are tagged - markdown `[text](url)` and HTML
`<a href>`. Images, code fences, inline code spans and stylesheet hrefs are
left alone: an image URL fires on page load rather than on a click, so tagging
one would report a visit nobody made, and a query string inside a code sample
changes what the sample does. The tag goes before any `#fragment`, and it is
the only `utm_` parameter on the link.

**Every broken link in the READMEs is repaired.** 41 files changed, 75 insertions(+), 75 deletions(-).

## Across the corpus

Following every clickable Iron link - 1,114 of them, not just the 606
canonical `Full guide` lines earlier passes checked - found **137 that did not
resolve to themselves**. All of them are now fixed:

- 62 answered 404, including 11 IronXL download packages that do not exist,
  and a family of `ironsoftware.com/csharp/pdf/...` paths - IronPDF's docs are
  on `ironpdf.com`.
- 40 redirected somewhere else, often to a different product's home page.
- 22 were written as a *path* where the site expects a *fragment*. The site
  301s `/csharp/ocr/trial-license` to `/csharp/ocr/#trial-license` and drags
  the query string in behind the fragment, where a browser never sends it.
- 11 GitHub links had been rewritten onto an Iron host, in four different
  shapes.
- 21 were `www.`, a missing trailing slash, or `http://`.

**999 unique links now resolve to themselves.** The 8 exceptions are package
`.zip` and `.jar` downloads that legitimately redirect to the release host.

## How it was verified

Every replacement was fetched over HTTP and required to answer 200 **at
itself** - a 200 after a redirect is not evidence a link is right. Where the
site's own redirect named a successor, that was used; where the redirect named
something the link did not mean, it was not. `/contact-us/` redirects to
`/contact-us/sales/`, but every occurrence sat under "Get Support", so those
point at `/contact-us/support/`.

Two defects were found in the process that no link check would report: six
platform-tile images on the IronPDF quickstart were 404 for the same
wrong-host reason as the links beside them, and a 404 image in IronWebScraper
turned out to be spelled *correctly* in the repo and incorrectly on the server.
