### PR TITLE
Correct the README's claim that documents can be saved to a MemoryStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each folder contains a self-contained .NET project you can open and run:
 - Page setup: paper size, orientation, margins, background color
 - Bullet and numbered lists with custom indentation and nesting
 - Find-and-replace and content extraction for data processing
-- Saving to file, `MemoryStream`, or `byte[]` for HTTP delivery
+- Saving to a file path with `SaveAs`, or to `byte[]` with `Save()` for in-memory and HTTP delivery
 
 ## Platform support
 


### PR DESCRIPTION
`README.md` listed, under **Common tasks covered**:

> Saving to file, `MemoryStream`, or `byte[]` for HTTP delivery

`WordDocument` has no save member that accepts a `Stream`. Reflected against
IronWord **2026.8.1**, the shipped surface is:

```
Byte[] Save()
Void   Save(String filePath)
Void   SaveAs(String filePath)
```

A reader who went looking for `SaveAs(stream)` on the strength of that line
would not find one. `Save()` returns a `byte[]`, which the caller can wrap in a
`MemoryStream` themselves — so the capability is reachable, but not under the
name the README implied.

Checked against the shipped assembly rather than the documentation site, which
is the rule this corpus follows: earlier phases found live docs pages
documenting APIs their own package does not ship.

The neighbouring image claim was checked in the same pass and **is** accurate,
so it is untouched — `ImageContent` has a `(Stream)` constructor and
`Paragraph.AddImage` accepts `ImageContent`, `Stream`, `String` or `AnyBitmap`.

Found while investigating issues #1 and #2 for this repository.